### PR TITLE
Fixed lucky streak crash, added decimal scale setting

### DIFF
--- a/SnakeEyes/Code/Scenes/game_mods.py
+++ b/SnakeEyes/Code/Scenes/game_mods.py
@@ -31,14 +31,14 @@ class GameMods:
         self.GAME_FONT.render_to(self.screen, (10, 20), "Game Mods", Settings.COLOR_TEXT)
 
         for p in self.game.Players:
-            self.GAME_FONT.render_to(self.screen, (80+(300*(p.playerNum-1)), 50), "Player "+str(p.playerNum)+": $"+str(f'{p.score:,}'), Settings.COLOR_TEXT)
+            self.GAME_FONT.render_to(self.screen, (80+(300*(p.playerNum-1)), 50), "Player "+str(p.playerNum)+": $"+str(f'{p.score:,.{Settings.ROUNDING_PRECISION}f}'), Settings.COLOR_TEXT)
             self.GAME_FONT.render_to(self.screen, (80+(300*(p.playerNum-1)), 70), "Available Mods ", Settings.COLOR_TEXT)
             self.screen.blit(self.charm, (75+(300*(p.playerNum-1)), 90))
             self.screen.blit(self.cash, (130+(300*(p.playerNum-1)), 100))
             self.screen.blit(self.dice, (175 + (300 * (p.playerNum - 1)), 85))
             self.GAME_FONT.render_to(self.screen, (80+(300*(p.playerNum-1)), 150), self.available_mods[p.modSelection].name, Settings.COLOR_TEXT)
             #self.GAME_FONT.render_to(self.screen, (80+(300*(p.playerNum-1)), 340), modifier.available_modifiers[p.modSelection].description, Settings.COLOR_TEXT)
-            self.GAME_FONT.render_to(self.screen, (80+(300*(p.playerNum-1)), 190), "$"+str(f'{round(self.available_mods[p.modSelection].cost, 2):,}'), Settings.COLOR_TEXT)
+            self.GAME_FONT.render_to(self.screen, (80+(300*(p.playerNum-1)), 190), "$"+str(f'{round(self.available_mods[p.modSelection].cost, 2):,.{Settings.ROUNDING_PRECISION}f}'), Settings.COLOR_TEXT)
             #self.drawText(self.screen, modifier.available_modifiers[p.modSelection].description, pygame.Rect(80+(300*(p.playerNum-1)), 340, 300, 300), self.GAME_FONT)
             offset = 0
             send = ''

--- a/SnakeEyes/Code/Scenes/game_status.py
+++ b/SnakeEyes/Code/Scenes/game_status.py
@@ -116,8 +116,15 @@ class GameStatus:
         #Player Bars
         pCurIndex = 1
         for p in self.game.Players:
+            #Handle decimals
+            pScore = float(self.game.getScore(p.playerNum))
+            if (Settings.ROUNDING_PRECISION != 0):
+                pScore = round(pScore, Settings.ROUNDING_PRECISION)
+            else:
+                pScore = int(pScore)
+
             #Score Bar
-            curBarWidth = minBarWidth + (barGoalWidth * (float(self.game.getScore(p.playerNum)) / Preferences.FINISHLINE_SCORE))
+            curBarWidth = minBarWidth + (barGoalWidth * (pScore / Preferences.FINISHLINE_SCORE))
             # curBarWidth = minBarWidth + barGoalWidth #DEBUG
             rect = pygame.Rect( barLeft, VerticalPadding+((pCurIndex-1)*(barHeight + bufferBetween)), curBarWidth, barHeight) #x, y, width, height
             pygame.draw.rect(self.screen, p.color, rect)
@@ -128,7 +135,7 @@ class GameStatus:
             player_num_rect.midright = (rect.left - 5, rect.centery - Settings.FONT_SIZE/2)
             self.GAME_FONT.render_to(self.screen, player_num_rect, player_num_text, Settings.COLOR_TEXT)
             
-            player_score_text = "$"+str(f'{int(self.game.getScore(p.playerNum)):,}')
+            player_score_text = "$"+str(f'{pScore:,.{Settings.ROUNDING_PRECISION}f}')
             player_score_rect = self.GAME_FONT.get_rect(player_score_text)
             player_score_rect.midright = (rect.left - 5, rect.centery + Settings.FONT_SIZE/2)
             self.GAME_FONT.render_to(self.screen, player_score_rect, player_score_text, Settings.COLOR_TEXT)
@@ -141,7 +148,7 @@ class GameStatus:
         goal_text_rect.midleft = (goal_rect.right + 5, goal_rect.centery - Settings.FONT_SIZE/2)
         self.GAME_FONT.render_to(self.screen, goal_text_rect, goal_text, Settings.COLOR_TEXT)
 
-        goal_score_text = "$"+str(f'{Preferences.FINISHLINE_SCORE:,}')
+        goal_score_text = "$"+str(f'{Preferences.FINISHLINE_SCORE:,.{Settings.ROUNDING_PRECISION}f}')
         goal_score_rect = self.GAME_FONT.get_rect(goal_score_text)
         goal_score_rect.midleft = (goal_rect.right + 5, goal_rect.centery + Settings.FONT_SIZE/2)
         self.GAME_FONT.render_to(self.screen, goal_score_rect, goal_score_text, Settings.COLOR_TEXT)

--- a/SnakeEyes/Code/Scenes/game_win.py
+++ b/SnakeEyes/Code/Scenes/game_win.py
@@ -120,7 +120,7 @@ class GameWin:
             pygame.draw.rect(self.screen, (150, 150, 150), image_back)
             self.screen.blit(image, (image_x, image_y))
 
-            winner_text = f"${self.sorted_players[0].score:,}"
+            winner_text = f"${self.sorted_players[0].score:,.{Settings.ROUNDING_PRECISION}f}"
             currentFontSize = scoreTextSize
             currentFont = pygame.freetype.Font("Fonts/HighlandGothicFLF-Bold.ttf", currentFontSize)
             winner_score_rect = currentFont.get_rect(winner_text)
@@ -162,7 +162,7 @@ class GameWin:
             pygame.draw.rect(self.screen, (150, 150, 150), image_back)
             self.screen.blit(image, (image_x, image_y))
 
-            second_text = f"${self.sorted_players[1].score:,}"
+            second_text = f"${self.sorted_players[1].score:,.{Settings.ROUNDING_PRECISION}f}"
             currentFontSize = scoreTextSize*secondScale
             currentFont = pygame.freetype.Font("Fonts/HighlandGothicFLF-Bold.ttf", currentFontSize)
             second_score_rect = currentFont.get_rect(second_text)
@@ -204,7 +204,7 @@ class GameWin:
             pygame.draw.rect(self.screen, (150, 150, 150), image_back)
             self.screen.blit(image, (image_x, image_y))
 
-            third_text = f"${self.sorted_players[2].score:,}"
+            third_text = f"${self.sorted_players[2].score:,.{Settings.ROUNDING_PRECISION}f}"
             currentFontSize = scoreTextSize*thirdScale
             currentFont = pygame.freetype.Font("Fonts/HighlandGothicFLF-Bold.ttf", currentFontSize)
             third_score_rect = currentFont.get_rect(third_text)
@@ -246,7 +246,7 @@ class GameWin:
             pygame.draw.rect(self.screen, (150, 150, 150), image_back)
             self.screen.blit(image, (image_x, image_y))
 
-            fourth_text = f"${self.sorted_players[3].score:,}"
+            fourth_text = f"${self.sorted_players[3].score:,.{Settings.ROUNDING_PRECISION}f}"
             currentFontSize = scoreTextSize*fourthScale
             currentFont = pygame.freetype.Font("Fonts/HighlandGothicFLF-Bold.ttf", currentFontSize)
             fourth_score_rect = currentFont.get_rect(fourth_text)

--- a/SnakeEyes/Code/game.py
+++ b/SnakeEyes/Code/game.py
@@ -480,8 +480,8 @@ class Game:
                             adjusted_position = p.position - pygame.Vector2(30, 50)
                             self.screen.blit(sprite.current_sprite, adjusted_position)
         
-            self.GAME_FONT.render_to(self.screen, (p.gr.x-18, p.gr.y-42), "$"+str(f'{round(p.score, 2):,}'), (0, 0, 0))
-            self.GAME_FONT.render_to(self.screen, (p.gr.x-20, p.gr.y-40), "$"+str(f'{round(p.score, 2):,}'), (255, 255, 255))
+            self.GAME_FONT.render_to(self.screen, (p.gr.x-18, p.gr.y-42), "$"+str(f'{round(p.score, Settings.ROUNDING_PRECISION):,.{Settings.ROUNDING_PRECISION}f}'), (0, 0, 0))
+            self.GAME_FONT.render_to(self.screen, (p.gr.x-20, p.gr.y-40), "$"+str(f'{round(p.score, Settings.ROUNDING_PRECISION):,.{Settings.ROUNDING_PRECISION}f}'), (255, 255, 255))
             self.GAME_FONT.render_to(self.screen, (p.gr.x-18, p.gr.y-22), "P"+str(p.playerNum), (0, 0, 0))
             self.GAME_FONT.render_to(self.screen, (p.gr.x-20, p.gr.y-20), "P"+str(p.playerNum), (255, 255, 255))
 
@@ -500,11 +500,11 @@ class Game:
 
 
             if p.status == 0:
-                printTemp = round(p.tmpScore+p.score, 2)
-                self.GAME_FONT.render_to(self.screen, (p.position.x-21, p.position.y+19), "$"+str(f'{round(p.tmpScore, 2):,}'), (0,0,0))
-                self.GAME_FONT.render_to(self.screen, (p.position.x-20, p.position.y+20), "$"+str(f'{round(p.tmpScore, 2):,}'), (255, 255, 255))
-                self.GAME_FONT.render_to(self.screen, (p.position.x-21, p.position.y+39), "$"+str(f'{round(printTemp, 2):,}'), (0,0,0))
-                self.GAME_FONT.render_to(self.screen, (p.position.x-20, p.position.y+40), "$"+str(f'{round(printTemp, 2):,}'), (175, 175, 175))
+                printTemp = round(p.tmpScore+p.score, Settings.ROUNDING_PRECISION)
+                self.GAME_FONT.render_to(self.screen, (p.position.x-21, p.position.y+19), "$"+str(f'{round(p.tmpScore, Settings.ROUNDING_PRECISION):,.{Settings.ROUNDING_PRECISION}f}'), (0,0,0))
+                self.GAME_FONT.render_to(self.screen, (p.position.x-20, p.position.y+20), "$"+str(f'{round(p.tmpScore, Settings.ROUNDING_PRECISION):,.{Settings.ROUNDING_PRECISION}f}'), (255, 255, 255))
+                self.GAME_FONT.render_to(self.screen, (p.position.x-21, p.position.y+39), "$"+str(f'{round(printTemp, Settings.ROUNDING_PRECISION):,.{Settings.ROUNDING_PRECISION}f}'), (0,0,0))
+                self.GAME_FONT.render_to(self.screen, (p.position.x-20, p.position.y+40), "$"+str(f'{round(printTemp, Settings.ROUNDING_PRECISION):,.{Settings.ROUNDING_PRECISION}f}'), (175, 175, 175))
                 self.GAME_FONT.render_to(self.screen, (p.position.x-16, p.position.y-69), "P"+str(p.playerNum), (0,0,0))
                 self.GAME_FONT.render_to(self.screen, (p.position.x-15, p.position.y-70), "P"+str(p.playerNum), (255, 255, 255))
                 self.GAME_FONT.render_to(self.screen, (p.position.x-21, p.position.y+59), p.scoreText, (0,0,0))
@@ -1011,10 +1011,10 @@ class Game:
                     printScore = self.award
                     p.tmpScore = p.tmpScore+printScore
                 
-                p.tmpScore = round(p.tmpScore, 2)
-                printScore = round(printScore, 2)
+                p.tmpScore = round(p.tmpScore, Settings.ROUNDING_PRECISION)
+                printScore = round(printScore, Settings.ROUNDING_PRECISION)
                 p.status = 0
-                p.scoreText = "+"+str(f'{round(printScore, 2):,}')
+                p.scoreText = "+"+str(f'{round(printScore, Settings.ROUNDING_PRECISION):,.{Settings.ROUNDING_PRECISION}f}')
                 store.scoreTextColor = (0,255,0)
                 #print("Default Roll Finished")
 

--- a/SnakeEyes/Code/modifier.py
+++ b/SnakeEyes/Code/modifier.py
@@ -1,3 +1,5 @@
+from SnakeEyes.Code.settings import Settings
+
 class Modifier:
     #def __init__(self, name, description, cost, apply_modifier):
     def __init__(self, name, description, cost):
@@ -46,7 +48,10 @@ def lucky_streak_modifier(score, streak):
     #print("Original: "+str(score))
     #print("Streak: "+str(streak))
     #print("Modified: "+str(temp))
-    return round(temp, 2)
+    if (Settings.ROUNDING_PRECISION != 0):
+        return round(temp, Settings.ROUNDING_PRECISION)
+    else:
+        return int(temp)
     
     
 

--- a/SnakeEyes/Code/settings.py
+++ b/SnakeEyes/Code/settings.py
@@ -13,5 +13,5 @@ class Settings:
     COLOR_ACCENT = (230, 230, 230)
     COLOR_TEXT = (255, 255, 255)
 
-    
+    ROUNDING_PRECISION = 0 #Decimal precision of scores, costs, etc
 

--- a/SnakeEyes/Code/settings.py
+++ b/SnakeEyes/Code/settings.py
@@ -13,5 +13,5 @@ class Settings:
     COLOR_ACCENT = (230, 230, 230)
     COLOR_TEXT = (255, 255, 255)
 
-    ROUNDING_PRECISION = 0 #Decimal precision of scores, costs, etc
+    ROUNDING_PRECISION = 0 #Decimal scale of scores, costs, etc
 


### PR DESCRIPTION
- Added a setting to change the decimal scale of scores. Setting it to 0 will make the game use exclusively whole numbers. Setting it to 2 will make every in-game number display as a float with a scale of 2 decimals (Ex: $10 will be shown as $10.00)
- Altered how lucky streak returns scores, to prevent casting an int to a float unintentionally (which would display as a decimal)
- Fixed how game_status.py handles player scores, allowing for floats to not crash the game and decimals to be displayed with correct scale 

All of these changes make the decimal scale consistent. Before there was a mix of whole numbers, floats with a scale of 1, and floats with a scale of 2. Now they will all have the same decimal scale.